### PR TITLE
fix tray icon with minimized state

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3293,7 +3293,7 @@ void MainWindow::changeEvent(QEvent *event)
 {
     if(event->type() == QEvent::WindowStateChange)
     {
-        if(isMinimized())
+        if(isMinimized() && g::options.nIconTray !=0)
             hide();
     }
     QMainWindow::changeEvent(event);


### PR DESCRIPTION
Добрый!

Если настройка трея стоит "не показывать" и окно свернули, с панели задач пропадает иконка, и процесс остаётся висеть в памяти.

После ПР, соответственно, программа сворачивается в панель задач.
Для других вариантов настроек, поведение без изменений.